### PR TITLE
allow homebrew to continue even as root

### DIFF
--- a/images/ubuntu/scripts/build/install-homebrew.sh
+++ b/images/ubuntu/scripts/build/install-homebrew.sh
@@ -9,6 +9,9 @@
 source $HELPER_SCRIPTS/etc-environment.sh
 source $HELPER_SCRIPTS/install.sh
 
+# DEVZERO START - touch /.dockerenv to allow brew to continue even as root
+touch /.dockerenv
+
 # Install the Homebrew on Linux
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 
@@ -29,3 +32,6 @@ if [[ -e $gfortran ]]; then
 fi
 
 invoke_tests "Tools" "Homebrew"
+
+# DEVZERO END - remove /.dockerenv
+rm -f /.dockerenv


### PR DESCRIPTION
# Description

Adds a "hack" to allow homebrew to continue setting up since we run the install as root. Note there's already a carveout for CI tools: https://github.com/Homebrew/install/blob/e4fb3cd758e458e13d2f5cb7099ccea40897d2b0/install.sh#L327-L330

#### Related issue:

## Check list
- [ ] Related issue / work item is attached
- [ ] Tests are written (if applicable)
- [ ] Documentation is updated (if applicable)
- [ ] Changes are tested and related VM images are successfully generated
