### PR TITLE
Disable postgresql.service

### DIFF
--- a/images/ubuntu/scripts/build/install-postgresql.sh
+++ b/images/ubuntu/scripts/build/install-postgresql.sh
@@ -35,6 +35,6 @@ rm /usr/share/keyrings/postgresql.gpg
 echo "postgresql $REPO_URL" >> $HELPER_SCRIPTS/apt-sources.txt
 
 # DEVZERO START - disabling as a hack cuz docker image and can't run things
-sudo systemctl enable postgresql.service
+# sudo systemctl enable postgresql.service
 # DEVZERO STOP
 # invoke_tests "Databases" "PostgreSQL"


### PR DESCRIPTION
This is kept disabled in gh runner as well:
- https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-postgresql.sh
- Making tests fail https://github.com/devzero-inc/services/actions/runs/12749875659/job/35533333835?pr=4089#step:7:625


cc @cmiller01 @dray92 
