### PR TITLE
[images] adding some examples for amazonlinux:2023

### DIFF
--- a/.github/workflows/runner-image-scale-set-build.yml
+++ b/.github/workflows/runner-image-scale-set-build.yml
@@ -26,16 +26,16 @@ jobs:
         build_opts:
           - base_image: devzeroinc/gha-runner-image-ubuntu
             base_tag: 22.04-devel
-            build_rule_name: build-ubuntu-image
-            push_rule_name: push-ubuntu-image
+            build_rule_name: build-ubuntu
+            push_rule_name: push-ubuntu
           - base_image: devzeroinc/gha-runner-image-ubuntu
             base_tag: 24.04-devel
-            build_rule_name: build-ubuntu-image
-            push_rule_name: push-ubuntu-image
+            build_rule_name: build-ubuntu
+            push_rule_name: push-ubuntu
           - base_image: amazonlinux
             base_tag: 2023
-            build_rule_name: build-fedora-image
-            push_rule_name: push-fedora-image
+            build_rule_name: build-fedora
+            push_rule_name: push-fedora
     runs-on: ubuntu-xl
     steps:
       - name: Checkout code

--- a/.github/workflows/runner-image-scale-set-build.yml
+++ b/.github/workflows/runner-image-scale-set-build.yml
@@ -23,7 +23,19 @@ jobs:
   build:
     strategy:
       matrix:
-        base_image: [22.04-devel, 24.04-devel]
+        build_opts:
+          - base_image: devzeroinc/gha-runner-image-ubuntu
+            base_tag: 22.04-devel
+            build_rule_name: build-ubuntu-image
+            push_rule_name: push-ubuntu-image
+          - base_image: devzeroinc/gha-runner-image-ubuntu
+            base_tag: 24.04-devel
+            build_rule_name: build-ubuntu-image
+            push_rule_name: push-ubuntu-image
+          - base_image: amazonlinux
+            base_tag: 2023
+            build_rule_name: build-fedora-image
+            push_rule_name: push-fedora-image
     runs-on: ubuntu-xl
     steps:
       - name: Checkout code
@@ -47,9 +59,9 @@ jobs:
         shell: bash
         run: |
           cd images/ubuntu/dockerfiles-scaleset
-          TAG=${{ matrix.base_image }} BASE_IMAGE=devzeroinc/gha-runner-image-ubuntu:${{ matrix.base_image}}
+          TAG=${{ matrix.build_opts.base_tag }} BASE_IMAGE=${{ matrix.build_opts.base_image }}:${{ matrix.build_opts.base_tag}}
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            make build-image
+            make ${{ matrix.build_opts.build_rule_name }}
           else
-            make push
+            make ${{ matrix.build_opts.push_rule_name }}
           fi

--- a/images/ubuntu/dockerfiles-scaleset/Dockerfile.AL23
+++ b/images/ubuntu/dockerfiles-scaleset/Dockerfile.AL23
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=devzeroinc/gha-runner-image-ubuntu:22.04-devel
+ARG BASE_IMAGE=amazonlinux:2023
 
 FROM ${BASE_IMAGE} AS initial
 
@@ -6,55 +6,53 @@ ARG ARCH=amd64
 ARG RUNNER_VERSION=2.322.0
 ARG RUNNER_USER_UID=1001
 
-ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update -y \
-    && apt-get install -y software-properties-common \
-    && add-apt-repository -y ppa:git-core/ppa \
-    && apt-get update -y \
-    && apt-get install -y --no-install-recommends \
+RUN dnf update -y \
+    && dnf install -y \
     systemd \
-    systemd-sysv \
-    libsystemd0 \
     ca-certificates \
     dbus \
     iptables \
-    iproute2 \
+    iproute \
     kmod \
-    locales \
+    glibc-langpack-en \
     sudo \
-    curl \
     git \
     vim \
     nano \
-    ssh \
-    ssh \
-    build-essential \
+    openssh-server \
+    gcc \
+    gcc-c++ \
+    make \
     htop \
-    dnsutils \
+    bind-utils \
     net-tools \
     less \
     wget \
     zip \
     unzip \
     udev \
-    jq
+    jq \
+    tar \
+    && dnf swap -y curl-minimal curl
 
+# Install Docker
+RUN dnf install -y docker \
+    && systemctl enable docker
 
-# Download latest git-lfs version
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    apt-get install -y --no-install-recommends git-lfs
+# Install latest git-lfs
+RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash && \
+    dnf install -y git-lfs
 
-RUN adduser --disabled-password --gecos "" --uid $RUNNER_USER_UID runner \
-    && usermod -aG sudo runner \
-    && echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers \
-    && echo "Defaults env_keep += \"DEBIAN_FRONTEND\"" >> /etc/sudoers
+RUN adduser --uid $RUNNER_USER_UID runner \
+    && usermod -aG wheel runner \
+    && echo "%wheel   ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # Create docker group and add runner user to it
 RUN groupadd docker || true \
     && usermod -aG docker runner
 
-# Enable sshing in
-RUN systemctl enable ssh
+# Enable SSH service
+RUN systemctl enable sshd
 
 RUN echo "runner:runner" | chpasswd
 
@@ -70,8 +68,9 @@ RUN if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "i386" ]; 
     && curl -fLo runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-${ARCH}-${RUNNER_VERSION}.tar.gz \
     && tar xzf ./runner.tar.gz \
     && rm runner.tar.gz \
-    && sudo ./bin/installdependencies.sh \
-    && sudo apt-get install -y libyaml-dev
+    # instead of `sudo ./bin/installdependencies.sh` since it cant determine OS
+    && sudo dnf install -y lttng-ust openssl-libs krb5-libs zlib libicu \
+    && sudo dnf install -y libyaml-devel
 
 RUN cd "${RUNNER_ASSETS_DIR}" \
     && curl -f -L -o runner-container-hooks.zip https://github.com/actions/runner-container-hooks/releases/download/v0.6.2/actions-runner-hooks-k8s-0.6.2.zip \
@@ -85,28 +84,21 @@ RUN sudo mkdir -p /opt/hostedtoolcache \
 
 USER root
 
-RUN update-alternatives --set iptables /usr/sbin/iptables-legacy \
-    && update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy
-
 COPY github-runner.service /etc/systemd/system/github-runner.service
 
 RUN systemctl enable github-runner
 
 RUN systemctl mask systemd-modules-load.service \
-    systemd-resolved.service \
-    unattended-upgrades.service
+    systemd-resolved.service
 
-# trying multi-stage build, but if you have a very large base image it won't help much
-# FROM scratch
-# COPY --from=initial / /
 ARG CACHEBUST
 RUN echo ${CACHEBUST}
 ENV CACHEBUST=${CACHEBUST}
 
 ARG DZ_TAR=dz.tar.gz
-RUN wget -O $(DZ_TAR) https://get.devzero.io/stable/linux-$(ARCH)/dz.tar.gz \
-    && tar -xzf $(DZ_TAR) \
-    && rm -rf $(DZ_TAR) \
+RUN wget -O ${DZ_TAR} https://get.devzero.io/stable/linux-${ARCH}/dz.tar.gz \
+    && tar -xzf ${DZ_TAR} \
+    && rm -rf ${DZ_TAR} \
     && mv dzcmd /usr/bin
 RUN chmod +x /usr/bin/dzcmd
 RUN ln -s /usr/bin/dzcmd /usr/bin/dzboot

--- a/images/ubuntu/dockerfiles-scaleset/Makefile
+++ b/images/ubuntu/dockerfiles-scaleset/Makefile
@@ -4,35 +4,51 @@ MAKEFLAGS += -j 4
 ARCH ?= amd64
 
 DZ_TAR := dz.tar.gz
-DZ_DIR := dz
 
 DOCKER_REGISTRY ?= docker.io/devzeroinc
 IMAGE_NAME ?= gha-scale-set-runner-ubuntu
 BASE_IMAGE ?= devzeroinc/gha-runner-image-ubuntu:22.04-devel
 TAG ?= $(shell date -u +"%Y-%m-%d")-$(shell git describe --always --abbrev=6 --dirty --match="")-devel
-
-.PHONY: download-cli
-download-cli:
-	wget -O $(DZ_TAR) https://get.devzero.io/stable/linux-$(ARCH)/dz.tar.gz
-	tar -xzf $(DZ_TAR)
-	rm -rf $(DZ_TAR)
 	
-.PHONY: build-image
-build-image: download-cli ## Build the image
+.PHONY: build-ubuntu-image
+build-ubuntu-image: ## Build the Ubuntu image
 	docker build --platform linux/$(ARCH) --build-arg="CACHEBUST=$(TAG)" --build-arg="ARCH=$(ARCH)" --build-arg="BASE_IMAGE=$(BASE_IMAGE)" -t $(IMAGE_NAME):$(TAG) .
 
-.PHONY: save-image
-save-image: download-cli
+.PHONY: build-fedora-image
+build-fedora-image: ## Build the Fedora image
+	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
+	docker build --platform linux/$(ARCH) --build-arg="CACHEBUST=$(TAG)" --build-arg="ARCH=$(ARCH)" -t $(IMAGE_NAME):$(TAG) -f Dockerfile.AL23 .
+
+.PHONY: save-ubuntu-image
+save-ubuntu-image: ## Save the Ubuntu image to the local docker daemon
 	docker build --platform linux/$(ARCH) --build-arg="ARCH=$(ARCH)" --build-arg="CACHEBUST=$(TAG)" -t $(IMAGE_NAME):$(ARCH)-$(TAG) .
 	docker save -o ./$(IMAGE_NAME)_$(TAG)_$(ARCH).tar $(IMAGE_NAME):$(ARCH)-$(TAG)
 
-.PHONY: push
-push: build-image ## Push the image to the registry using the TAG
+.PHONY: save-fedora-image
+save-fedora-image: ## Save the Fedora image to the local docker daemon
+	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
+	docker build --platform linux/$(ARCH) --build-arg="ARCH=$(ARCH)" --build-arg="CACHEBUST=$(TAG)" -t $(IMAGE_NAME):$(ARCH)-$(TAG) -f Dockerfile.AL23 .
+	docker save -o ./$(IMAGE_NAME)_$(TAG)_$(ARCH).tar $(IMAGE_NAME):$(ARCH)-$(TAG)
+
+.PHONY: push-ubuntu-image
+push-ubuntu-image: build-ubuntu-image ## Push the Ubuntu image to the registry using the TAG
 	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
 	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
 
-.PHONY: latest
-latest: build-image ## Push the image to the registry using latest tag
+.PHONY: push-fedora-image
+push-fedora-image: build-fedora-image ## Push the Fedora image to the registry using the TAG
+	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
+	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
+	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
+
+.PHONY: latest-ubuntu
+latest-ubuntu: build-ubuntu-image ## Push the Ubuntu image to the registry using latest tag
+	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
+	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
+
+.PHONY: latest-fedora
+latest-fedora: build-fedora-image ## Push the Fedora image to the registry using latest tag
+	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
 	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
 	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
 

--- a/images/ubuntu/dockerfiles-scaleset/Makefile
+++ b/images/ubuntu/dockerfiles-scaleset/Makefile
@@ -1,59 +1,64 @@
 .DEFAULT_GOAL := help
+
 # Run targets in parallel
 MAKEFLAGS += -j 4
-ARCH ?= amd64
 
+ARCH ?= amd64
 DZ_TAR := dz.tar.gz
 
 DOCKER_REGISTRY ?= docker.io/devzeroinc
-IMAGE_NAME ?= gha-scale-set-runner-ubuntu
+UBUNTU_IMAGE_NAME := gha-scale-set-runner-ubuntu
+FEDORA_IMAGE_NAME := gha-scale-set-runner-amazonlinux
 BASE_IMAGE ?= devzeroinc/gha-runner-image-ubuntu:22.04-devel
-TAG ?= $(shell date -u +"%Y-%m-%d")-$(shell git describe --always --abbrev=6 --dirty --match="")-devel
-	
-.PHONY: build-ubuntu-image
-build-ubuntu-image: ## Build the Ubuntu image
-	docker build --platform linux/$(ARCH) --build-arg="CACHEBUST=$(TAG)" --build-arg="ARCH=$(ARCH)" --build-arg="BASE_IMAGE=$(BASE_IMAGE)" -t $(IMAGE_NAME):$(TAG) .
+TAG ?= $(shell date -u +"%Y-%m-%d")-$(shell git describe --always --abbrev=6 --dirty --match="")
 
-.PHONY: build-fedora-image
-build-fedora-image: ## Build the Fedora image
-	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
-	docker build --platform linux/$(ARCH) --build-arg="CACHEBUST=$(TAG)" --build-arg="ARCH=$(ARCH)" -t $(IMAGE_NAME):$(TAG) -f Dockerfile.AL23 .
+define build_image
+	docker build --platform linux/$(ARCH) \
+		--build-arg="CACHEBUST=$(TAG)" \
+		--build-arg="ARCH=$(ARCH)" \
+		$(if $(2),--build-arg="BASE_IMAGE=$(2)") \
+		-f $(3) . \
+		-t $(1):$(TAG)
+endef
 
-.PHONY: save-ubuntu-image
-save-ubuntu-image: ## Save the Ubuntu image to the local docker daemon
-	docker build --platform linux/$(ARCH) --build-arg="ARCH=$(ARCH)" --build-arg="CACHEBUST=$(TAG)" -t $(IMAGE_NAME):$(ARCH)-$(TAG) .
-	docker save -o ./$(IMAGE_NAME)_$(TAG)_$(ARCH).tar $(IMAGE_NAME):$(ARCH)-$(TAG)
+define save_image
+	docker save -o ./$(1)_$(TAG)_$(ARCH).tar $(1):$(ARCH)-$(TAG)
+endef
 
-.PHONY: save-fedora-image
-save-fedora-image: ## Save the Fedora image to the local docker daemon
-	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
-	docker build --platform linux/$(ARCH) --build-arg="ARCH=$(ARCH)" --build-arg="CACHEBUST=$(TAG)" -t $(IMAGE_NAME):$(ARCH)-$(TAG) -f Dockerfile.AL23 .
-	docker save -o ./$(IMAGE_NAME)_$(TAG)_$(ARCH).tar $(IMAGE_NAME):$(ARCH)-$(TAG)
+define push_image
+	docker tag $(1):$(TAG) $(DOCKER_REGISTRY)/$(1):$(2)
+	docker push $(DOCKER_REGISTRY)/$(1):$(2)
+endef
 
-.PHONY: push-ubuntu-image
-push-ubuntu-image: build-ubuntu-image ## Push the Ubuntu image to the registry using the TAG
-	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
+.PHONY: build-ubuntu build-fedora
+build-ubuntu: ## Build the Ubuntu image
+	$(call build_image,$(UBUNTU_IMAGE_NAME),$(BASE_IMAGE),Dockerfile)
 
-.PHONY: push-fedora-image
-push-fedora-image: build-fedora-image ## Push the Fedora image to the registry using the TAG
-	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
-	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):$(TAG)
+build-fedora: ## Build the Fedora (Amazon Linux) image
+	$(call build_image,$(FEDORA_IMAGE_NAME),,Dockerfile.AL23)
 
-.PHONY: latest-ubuntu
-latest-ubuntu: build-ubuntu-image ## Push the Ubuntu image to the registry using latest tag
-	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
+.PHONY: save-ubuntu save-fedora
+save-ubuntu: build-ubuntu ## Save the Ubuntu image locally
+	$(call save_image,$(UBUNTU_IMAGE_NAME))
 
-.PHONY: latest-fedora
-latest-fedora: build-fedora-image ## Push the Fedora image to the registry using latest tag
-	$(eval IMAGE_NAME=gha-scale-set-runner-amazonlinux)
-	docker tag $(IMAGE_NAME):$(TAG) $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
-	docker push $(DOCKER_REGISTRY)/$(IMAGE_NAME):latest
+save-fedora: build-fedora ## Save the Fedora (Amazon Linux) image locally
+	$(call save_image,$(FEDORA_IMAGE_NAME))
+
+.PHONY: push-ubuntu push-fedora latest-ubuntu latest-fedora
+push-ubuntu: build-ubuntu ## Push Ubuntu image to registry
+	$(call push_image,$(UBUNTU_IMAGE_NAME),$(TAG))
+
+push-fedora: build-fedora ## Push Fedora (Amazon Linux) image to registry
+	$(call push_image,$(FEDORA_IMAGE_NAME),$(TAG))
+
+latest-ubuntu: build-ubuntu ## Push Ubuntu image with latest tag
+	$(call push_image,$(UBUNTU_IMAGE_NAME),latest)
+
+latest-fedora: build-fedora ## Push Fedora (Amazon Linux) image with latest tag
+	$(call push_image,$(FEDORA_IMAGE_NAME),latest)
 
 .PHONY: help
-help:  ## Show this help
+help: ## Show this help message
 	@echo "\nSpecify a command. The choices are:\n"
 	@grep -hE '^[0-9a-zA-Z_-]+:.*?## .*$$' ${MAKEFILE_LIST} | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[0;36m%-20s\033[m %s\n", $$1, $$2}'
 	@echo ""


### PR DESCRIPTION
# Description

- adding some examples for a base runner image for fedora/amazonlinux:2023 (just docker and some basic tooling)
- made the makefile steps a bit more modular and used some more vars in gh job matrix
- previously, makefile was downloading binary and that was getting copied into docker image; that's now changed to the download actually happening inside the build process
